### PR TITLE
Fix env formatting and typo

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -32,13 +32,13 @@ AZURE_SEARCH_SERVICE_ENDPOINT="<your azure ai search deployment url>"
 AZURE_SEARCH_ADMIN_KEY="<the management key of the ai search>"
 
 # cosmosdb for mongo - vcore 
-COSMOS_MONGO_CONNECTION_STRING = "<your cosmos mongo connection string>"
-COSMOS_INDEX_NAME = "embed-test-index"
-COSMOS_DBNAME = "embed-test-db"
-COSMOS_COLLECTION_NAME = "embed-test-collection"
+COSMOS_MONGO_CONNECTION_STRING="<your cosmos mongo connection string>"
+COSMOS_INDEX_NAME="embed-test-index"
+COSMOS_DBNAME="embed-test-db"
+COSMOS_COLLECTION_NAME="embed-test-collection"
 
 #postgres flexible server
-POSTGRES_HOST = "<your postgres server url>"
-POSTGRES_USER = "<the user you defined in as admin>"
-POSTGRES_PASSWORD = "<the password for the admin user>"
-POSTGRES_DB = "embed-test-db"
+POSTGRES_HOST="<your postgres server url>"
+POSTGRES_USER="<the user you defined in as admin>"
+POSTGRES_PASSWORD="<the password for the admin user>"
+POSTGRES_DB="embed-test-db"

--- a/0- Requirements/README.md
+++ b/0- Requirements/README.md
@@ -3,7 +3,7 @@ For this workshop you MUST have the following:
 # Requirements
 - Visual Studio Code
 - Python (tested with 3.10, 3.12)
-- Pyhton virtual environment tool (venv)
+- Python virtual environment tool (venv)
 - An Azure account 
 - Azure subscription onboarded into Azure OpenAI
 - Necessary permissions to deploy resources in the subscription


### PR DESCRIPTION
## Summary
- fix spaces around `=` in `.env.template` so it can be sourced by shell
- correct typo in requirements guide

## Testing
- `python3 -m pip install -r requirements.txt`
- `pytest -q`
- `bash -c 'source .env.template && echo $COSMOS_MONGO_CONNECTION_STRING'`

------
https://chatgpt.com/codex/tasks/task_e_6840c298e7a08321af3cb4e7f3350e04